### PR TITLE
Some cleanup before the workshop

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+target = "wasm32-unknown-emscripten"
+rustflags = ["-C", "link-args=-s ALLOW_MEMORY_GROWTH=1"]

--- a/README.md
+++ b/README.md
@@ -1,49 +1,35 @@
 # mandelbrot
-simple Mandelbrot set fractal visualiser
 
-## building
+`mandelbrot` is a simple Mandelbrot set fractal visualiser for use with our `gWasm` platform.
 
+## Building
 
-### native binary
-use plain `cargo build`
+Before building the program, you'll need to download and install the Emscripten SDK. Follow
+the instructions on [Emscripten SDK website] to get the latest copy of the SDK.
 
-### wasm target
-you need [Emscripten sdk](https://emscripten.org/docs/getting_started/downloads.html#installation-instructions)
-and a emscripten rust target 
+Next, install the `wasm32-unknown-emscripten` target. We assume you're using [rustup] to
+manage your Rust installation, so simply run in the terminal/command line
+
 ```
 rustup target add wasm32-unknown-emscripten
 ```
 
-then to build run
-```
-cargo rustc --target=wasm32-unknown-emscripten --release -- -C link-args="-s ALLOW_MEMORY_GROWTH=1"
-```
-
-### benchmarks
-I was using [sp-wasm](https://github.com/golemfactory/sp-wasm) to run WASM binary.
-Benchmarks are run on iMac, Intel Core i7, 4 GHz
+Finally, that should be you prepped and ready to build the crate. To do this, simply run
+in the terminal/command line
 
 ```
-$ bench '~/git/sp-wasm/target/release/wasm-sandbox -I x -O x -o out.png \
->  -w target/wasm32-unknown-emscripten/release/mandelbrot.wasm \
->  -j target/wasm32-unknown-emscripten/release/mandelbrot.js \
->  0.2 0.35 0.6 0.45 1000 1000' '~/git/mandelbrot/target/release/mandelbrot 0.2 0.35 0.6 0.45 1000 1000' 
-benchmarking bench/~/git/sp-wasm/target/release/wasm-sandbox -I x -O x -o out.png \
-  -w target/wasm32-unknown-emscripten/release/mandelbrot.wasm \
-  -j target/wasm32-unknown-emscripten/release/mandelbrot.js \
-  0.2 0.35 0.6 0.45 1000 1000
-time                 1.261 s    (1.218 s .. 1.285 s)
-                     1.000 R²   (1.000 R² .. 1.000 R²)
-mean                 1.276 s    (1.268 s .. 1.281 s)
-std dev              8.042 ms   (1.371 ms .. 10.49 ms)
-variance introduced by outliers: 19% (moderately inflated)
-
-benchmarking bench/~/git/mandelbrot/target/release/mandelbrot 0.2 0.35 0.6 0.45 1000 1000
-time                 337.2 ms   (NaN s .. 338.6 ms)
-                     1.000 R²   (1.000 R² .. 1.000 R²)
-mean                 336.7 ms   (336.2 ms .. 336.9 ms)
-std dev              361.0 μs   (41.75 μs .. 461.3 μs)
-variance introduced by outliers: 19% (moderately inflated)
+cargo build --release
 ```
 
-As we can see WASM execution takes ~4x longer.
+[Emscripten SDK website]: https://emscripten.org/docs/getting_started/downloads.html#installation-instructions
+[rustup]: https://rustup.rs
+
+## Running
+
+You'll need a copy of our [gwasm-runner] binary in order to run the program
+
+```
+gwasm-runner target/wasm32-unknown-emscripten/release/mandelbrot.wasm
+```
+
+[gwasm-runner]: https://github.com/golemfactory/gwasm-runner/releases

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
-pub mod utils;
-pub mod png_utils;
 pub mod mandelbrot;
+pub mod png_utils;
+pub mod utils;
 
+use crate::mandelbrot::Mandelbrot;
 use gwasm_api::dispatcher;
-use crate::mandelbrot::{Mandelbrot};
-
-
 
 fn main() {
-
     // This function will parse command line arguments and dispatch it
     // to one of split, execute and merge functions.
     dispatcher::run(&Mandelbrot::split, &Mandelbrot::execute, &Mandelbrot::merge).unwrap();

--- a/src/mandelbrot.rs
+++ b/src/mandelbrot.rs
@@ -1,17 +1,15 @@
-use std::path::{Path};
 use std::fs;
+use std::path::Path;
 
 use num_complex::Complex;
 use structopt::*;
 
-use serde::{Deserialize, Serialize};
+use gwasm_api::SplitContext;
 use gwasm_api::{Blob, Output, TaskResult};
-use gwasm_api::{SplitContext};
+use serde::{Deserialize, Serialize};
 
-use crate::utils;
 use crate::png_utils;
-
-
+use crate::utils;
 
 #[derive(Debug, StructOpt, Clone, Serialize, Deserialize)]
 pub struct MandelbrotParams {
@@ -35,7 +33,7 @@ struct Rect {
     startx: u32,
     starty: u32,
     endx: u32,
-    endy: u32
+    endy: u32,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -59,9 +57,7 @@ pub struct ComplexDef<T> {
 
 pub struct Mandelbrot;
 
-
 impl Mandelbrot {
-
     fn mandelbrot(c: Complex<f64>, max_iter: usize) -> usize {
         let mut z = Complex::from(0f64);
         let mut n = 0;
@@ -77,23 +73,25 @@ impl Mandelbrot {
             .into_iter()
             .flat_map(|y| {
                 let im = params.pixel_step.im * y as f64;
-                (params.area.startx..params.area.endx).into_iter().map(move |x| {
-                    let step = Complex::new(params.pixel_step.re * x as f64, im);
-                    let it = Mandelbrot::mandelbrot(params.start + step, params.max_iter);
-                    //            println!("{}x{}: it = {}", y, x, it);
-                    (params.max_iter as f64 * 255f64 / it as f64) as u8
-                })
+                (params.area.startx..params.area.endx)
+                    .into_iter()
+                    .map(move |x| {
+                        let step = Complex::new(params.pixel_step.re * x as f64, im);
+                        let it = Mandelbrot::mandelbrot(params.start + step, params.max_iter);
+                        //            println!("{}x{}: it = {}", y, x, it);
+                        (params.max_iter as f64 * 255f64 / it as f64) as u8
+                    })
             })
             .collect::<Vec<u8>>();
 
-        return data
+        return data;
     }
 
     fn merge_vecs(partial_results: Vec<Vec<u8>>) -> Vec<u8> {
         partial_results.into_iter().flatten().collect::<Vec<u8>>()
     }
 
-    pub fn split(context: &mut SplitContext) -> Vec<(ExecuteParams, Output)> {
+    pub fn split(context: &mut dyn SplitContext) -> Vec<(ExecuteParams, Output)> {
         let params = utils::parse_args::<MandelbrotParams>(context.args());
 
         let s = Complex::new(params.sx, params.sy);
@@ -103,23 +101,44 @@ impl Mandelbrot {
         let scale = Complex::new(delta.re / size.re, delta.im / size.im);
 
         // Preapre params common for all subtasks. Create zero area to replace in future on per subtasks basis.
-        let area = Rect { startx: 0, starty: 0, endx: 0, endy: 0 };
-        let common_params = ExecuteParams { start: s, pixel_step: scale, max_iter: params.max_iter, area };
+        let area = Rect {
+            startx: 0,
+            starty: 0,
+            endx: 0,
+            endy: 0,
+        };
+        let common_params = ExecuteParams {
+            start: s,
+            pixel_step: scale,
+            max_iter: params.max_iter,
+            area,
+        };
 
         let mut split_params = Vec::with_capacity(params.num_subtasks);
         for part in 0..params.num_subtasks {
             let starty = (part as u32 * params.height) / params.num_subtasks as u32;
             let endy = ((part as u32 + 1) * params.height) / params.num_subtasks as u32;
 
-            let area = Rect { startx: 0, starty, endx: params.width, endy };
+            let area = Rect {
+                startx: 0,
+                starty,
+                endx: params.width,
+                endy,
+            };
 
-            split_params.push((ExecuteParams { area, ..common_params }, context.new_blob()))
+            split_params.push((
+                ExecuteParams {
+                    area,
+                    ..common_params
+                },
+                context.new_blob(),
+            ))
         }
 
         return split_params;
     }
 
-    pub fn execute(params: ExecuteParams, png: Output) -> (Blob, ) {
+    pub fn execute(params: ExecuteParams, png: Output) -> (Blob,) {
         let data = Mandelbrot::exec_to_vec(&params);
 
         let width = params.area.endx - params.area.startx;
@@ -130,12 +149,15 @@ impl Mandelbrot {
         return (Blob::from_output(png),);
     }
 
-    pub fn merge(args_vec: &Vec<String>, params: TaskResult<(ExecuteParams, Output), (Blob, )>) {
+    pub fn merge(args_vec: &Vec<String>, params: TaskResult<(ExecuteParams, Output), (Blob,)>) {
         let args = utils::parse_args::<MandelbrotParams>(args_vec);
 
-        let partial_results = params.into_iter().map(|((_params, _), (image_blob, ))| {
-            png_utils::load_file(&mut image_blob.open().unwrap())
-        }).collect::<Vec<Vec<u8>>>();
+        let partial_results = params
+            .into_iter()
+            .map(|((_params, _), (image_blob,))| {
+                png_utils::load_file(&mut image_blob.open().unwrap())
+            })
+            .collect::<Vec<Vec<u8>>>();
 
         let data = Mandelbrot::merge_vecs(partial_results);
 
@@ -145,9 +167,9 @@ impl Mandelbrot {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(output_path).unwrap();
+            .open(output_path)
+            .unwrap();
 
         png_utils::save_file(&mut out_stream, &data, args.width, args.height).unwrap();
     }
 }
-

--- a/src/png_utils.rs
+++ b/src/png_utils.rs
@@ -1,24 +1,25 @@
 use failure::{Error, Fail};
-use std::io::{Write, Read};
-
+use std::io::{Read, Write};
 
 #[derive(Debug, Fail)]
 pub enum SaveFileError {
-    #[fail(display = "Can't save file. Buffer size doesn't match expected width {} and height {}.", width, height)]
-    NotMatchingSize {
-        width: u32,
-        height: u32,
-    },
+    #[fail(
+        display = "Can't save file. Buffer size doesn't match expected width {} and height {}.",
+        width, height
+    )]
+    NotMatchingSize { width: u32, height: u32 },
     #[fail(display = "Can't find parent")]
     NoParent,
 }
 
-
-
-pub fn save_file(output: &mut dyn Write, data: &Vec<u8>, width: u32, height: u32) -> Result<(), Error> {
-
+pub fn save_file(
+    output: &mut dyn Write,
+    data: &Vec<u8>,
+    width: u32,
+    height: u32,
+) -> Result<(), Error> {
     if data.len() != (width * height) as usize {
-        return Err(SaveFileError::NotMatchingSize{ width, height })?;
+        return Err(SaveFileError::NotMatchingSize { width, height })?;
     }
 
     let mut encoder = png::Encoder::new(output, width, height);
@@ -37,8 +38,5 @@ pub fn load_file(output: &mut dyn Read) -> Vec<u8> {
 
     reader.next_frame(&mut buf).unwrap();
 
-    return buf
+    return buf;
 }
-
-
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,5 @@
 use structopt::StructOpt;
 
-
-
-
 pub fn parse_args<ArgsType: StructOpt>(args: &Vec<String>) -> ArgsType {
     // Note: StructOpt wants to eat first argument as program name.
     // But we don't have program name at this point, so we must add fake argument.
@@ -11,5 +8,3 @@ pub fn parse_args<ArgsType: StructOpt>(args: &Vec<String>) -> ArgsType {
 
     return ArgsType::from_iter(args_copy.into_iter());
 }
-
-


### PR DESCRIPTION
Hey guys,

I've done some refactoring, and I've simplified the build process and the `README` itself (I hope!). To summarise, the changes are:

* fixed formatting (`cargo fmt`)
* added `.cargo/config` with default target set to `wasm32-unknown-emscripten` and appropriate `emcc` flags (`ALLOW_MEMORY_GROWTH`) -- I don't think we should even try and support native binaries, at least not for the workshop
* updated `README` -- I've taken the liberty of removing the section about benchmark results as it's not really relevant for the workshop and it might introduce some confusion among the participants about whether to use a native binary or Wasm one